### PR TITLE
Fix configuration parameter serializer queryset

### DIFF
--- a/webapp/api/serializers.py
+++ b/webapp/api/serializers.py
@@ -83,13 +83,11 @@ class ConfigurationParameterSlugSerializer(serializers.SlugRelatedField):
 
     def get_queryset(self):
         """
-        Return parameters from puppet classes from the same master
-        of the group
+        Return parameters from puppet class from the same master of the group
         """
-        classes = self.root.context.get("request", {}).data.get("classes", [])
+        puppet_class = self.root.context["puppet_class"]
         group = self.root.instance.group
-        query = {"environment": group.environment}
-        query.update({"name__in": [c.get("puppet_class") for c in classes]})
+        query = {"environment": group.environment, "name": puppet_class}
         return Parameter.objects.filter(
             puppet_class__in=PuppetClass.objects.filter(**query)
         )
@@ -124,6 +122,10 @@ class ConfigurationClassSerializer(serializers.ModelSerializer):
     class Meta(object):
         model = ConfigurationClass
         fields = ("puppet_class", "parameters")
+
+    def to_internal_value(self, data):
+        self.root.context["puppet_class"] = data["puppet_class"]
+        return super().to_internal_value(data)
 
 
 class ConfigurationSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
## Problem

The queryset of the `ConfigurationParameterSlugSerializer` was filtering by all the Puppet Classes sent on the PUT request, so any Parameter with the same `name` would accuse duplicated entry. 

For example, the following request would accuse an error of duplicated entries:

```
{
    "classes": [
        {
            "puppet_class": "class1",
            "parameters": [
                {
                    "value": "value1",
                    "raw_value": "value1",
                    "parameter": "parameter_name",    => same parameter name
                },
            ],
        },
        {
            "puppet_class": "class2",
            "parameters": [
                {
                    "value": "value2",
                    "raw_value": "value2",
                    "parameter": "parameter_name",    => same parameter name
                },
            ],
        }
    ]
}
```

## Solution

The solution was to filter by a specific PuppetClass, adding it as a context on the parent serializer:

```
    def to_internal_value(self, data):
        self.root.context["puppet_class"] = data["puppet_class"]
        return super().to_internal_value(data)
```

And filtering by the specified class name on the `ConfigurationParameterSlugSerializer` field queryset:

```
def get_queryset(self):
        """
        Return parameters from puppet class from the same master of the group
        """
        puppet_class = self.root.context["puppet_class"]
        group = self.root.instance.group
        query = {"environment": group.environment, "name": puppet_class}
        return Parameter.objects.filter(
            puppet_class__in=PuppetClass.objects.filter(**query)
        )
```
